### PR TITLE
an optional min_score argument to the __search semantic introspection…

### DIFF
--- a/rfcs/semantic-introspection.md
+++ b/rfcs/semantic-introspection.md
@@ -97,6 +97,13 @@ extend type Query {
     
     """Maximum number of results to return."""
     first: Int! = 10
+
+    """
+    Optional minimum score required for a result to be included.
+
+    When provided, all returned results MUST have score >= score_threshold.
+    """
+    min_score: Float
   ): [__SearchResult!]!
 }
 ```


### PR DESCRIPTION
… field

This PR introduces an optional min_score argument to the __search semantic introspection field, allowing clients to filter results by a minimum relevance score. When provided, servers must exclude any results with a score lower than the threshold before applying result limits, while preserving descending score ordering. This enables more precise and predictable semantic search behavior without changing existing defaults.