### PR TITLE
docs: rename min_score to minScore

### DIFF
--- a/rfcs/semantic-introspection.md
+++ b/rfcs/semantic-introspection.md
@@ -126,9 +126,9 @@ extend type Query {
     """
     Optional minimum score required for a result to be included.
 
-    When provided, all returned results MUST have score >= score_threshold.
+    When provided, all returned results MUST have score >= minScore.
     """
-    min_score: Float
+    minScore: Float
   ): [__SearchResult!]!
 }
 ```


### PR DESCRIPTION
I noticed a typo in the comment of the Semantic Introspection RFC, so I thought I would just fix that. But then I realized the field name doesn't follow GraphQL's camelCase convention. I'd like to suggest renaming `min_score` to `minScore`!