### PR TITLE
Add Michael Rebello to July 2026 attendees

### DIFF
--- a/agendas/2026/07-Jul/23-graphql-ai-wg-july-2026.md
+++ b/agendas/2026/07-Jul/23-graphql-ai-wg-july-2026.md
@@ -24,6 +24,7 @@
 | :--------------- | :------------ | :----------------- | :-------------------- |
 | Kewei Qu (Host)  | @Keweiqu	     | Meta Platforms	    | Menlo Park, CA, USA   |
 | Anastasia Finogenova  | @AnastasiaRainMaker	     | Meta Platforms	    | Texas, USA   |
+| Michael Rebello  | @rebello95    | Airbnb             | San Diego, CA, USA    |
 
 ## Agenda
 


### PR DESCRIPTION
Adding myself to the attendees list for the July 23, 2026 GraphQL AI WG meeting.